### PR TITLE
docs: how to enable capacitor

### DIFF
--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -45,17 +45,30 @@ The first time you start a Nuxt project with `@nuxtjs/ionic` enabled, a `ionic.c
 
 The good news is that it's installed by default with `@nuxtjs/ionic`, but you will need to enable it and choose what platforms you want to support.
 
+> The Ionic CLI is available via `npx` or can be installed globally with `npm install -g @ionic/cli` or `yarn global install @ionic/cli`.
+
 ```bash
-npx @ionic/cli integrations enable capacitor # or yarn ionic integrations add capacitor
-npx cap add ios # or yarn cap add ios
-npx cap add android # or yarn cap add android
+npx @ionic/cli integrations enable capacitor # or ionic integrations enable capacitor
+npx @ionic/cli capacitor add ios # or ionic capacitor add ios
+npx @ionic/cli capacitor add android # or ionic capacitor add android
 ```
 
+### Run on iOS or Android
+
+Once an Android or iOS project is added with Capacitor, you can run your app on an iOS or Android emulator.
+
 ::alert
-After building your Nuxt app with `npx nuxi generate`, you will need to run `npx cap sync` to update your Capacitor project directories with your latest app build.
+Android Studio and SDK (for Android projects) or XCode (for iOS projects) are required to use the `npx cap open` or `npx cap run` command. See the [Capacitor Environment Setup docs](https://capacitorjs.com/docs/getting-started/environment-setup) for details.
 ::
 
-Find out more about how to use Capacitor with Ionic at https://capacitorjs.com/docs/getting-started/with-ionic.
+To build, sync, and run your app:
+
+1. Create a web build with `npx nuxi generate` or `npx nuxi build`.
+2. Run `npx cap sync` to update your Capacitor project directories with your latest app build.
+3. Run `npx cap run android` or `npx cap run ios` to run the app from the command line using an installed device **OR**
+4. _(Optional)_ Run `npx cap open android` or `npx cap open ios` to open the project in Android Studio or XCode, respectively.
+
+> Remember to run `npx cap sync` after every new build to ensure your Android and/or iOS project is up-to-date.
 
 ## Options
 
@@ -73,7 +86,7 @@ export default defineNuxtConfig({
     },
     config: {
       //
-    }
+    },
   },
 })
 ```

--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -86,7 +86,7 @@ export default defineNuxtConfig({
     },
     config: {
       //
-    },
+    }
   },
 })
 ```


### PR DESCRIPTION
- Adds more instructions for running an app on Android and iOS with Capacitor, including environment setup requirements.
- Updates installation instructions to use Ionic CLI to ensure all Capacitor packages are installed correctly when adding Android or iOS
- Removes yarn commands, which don't install the packages

Note: if people want to use `yarn cap add ios/android` they could, but would need to run `yarn install @capacitor/ios/android` first. I can clarify this in the docs, but would recommend they just use the Ionic CLI for simplicity.

This should resolve https://github.com/nuxt-modules/ionic/issues/114. 

Thanks!