### PR TITLE
Fix `yarn global` usage example

### DIFF
--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -45,7 +45,7 @@ The first time you start a Nuxt project with `@nuxtjs/ionic` enabled, a `ionic.c
 
 The good news is that it's installed by default with `@nuxtjs/ionic`, but you will need to enable it and choose what platforms you want to support.
 
-> The Ionic CLI is available via `npx` or can be installed globally with `npm install -g @ionic/cli` or `yarn global install @ionic/cli`.
+> The Ionic CLI is available via `npx` or can be installed globally with `npm install -g @ionic/cli` or `yarn global add @ionic/cli`.
 
 ```bash
 npx @ionic/cli integrations enable capacitor # or ionic integrations enable capacitor


### PR DESCRIPTION
`yarn global add` should be used instead of `yarn global install`, as per https://classic.yarnpkg.com/lang/en/docs/cli/global/.