### PR TITLE
docs: remove defineNuxtConfig import from playground

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,3 @@
-import { defineNuxtConfig } from 'nuxt'
-
 export default defineNuxtConfig({
   modules: ['@nuxtjs/ionic'],
   ionic: {


### PR DESCRIPTION
Closes #192

As documented in https://nuxt.com/docs/guide/directory-structure/nuxt.config, `defineNuxtConfig` is now auto imported. We'll either have to remove import (which this PR opts to do) or import it from `nuxt/config` instead.