### PR TITLE
fix: add `<div>` wrapper around animation slot

### DIFF
--- a/playground/pages/tabs/tab4.vue
+++ b/playground/pages/tabs/tab4.vue
@@ -17,16 +17,10 @@
           <IonLabel color="primary">
             <strong>Basic animation</strong>
           </IonLabel>
-          <IonAnimation
-            ref="animation1"
-            v-slot="{ animation }"
-            :duration="2000"
-            :fromTo="[
-              { property: 'opacity', fromValue: '1', toValue: '0.2' },
-              { property: 'transform', fromValue: 'translateX(0px)', toValue: 'translateX(-50px)' },
-            ]"
-            fill="forwards"
-          >
+          <IonAnimation id="animation1" v-slot="{ animation }" :duration="2000" :fromTo="[
+  { property: 'opacity', fromValue: '1', toValue: '0.2' },
+  { property: 'transform', fromValue: 'translateX(0px)', toValue: 'translateX(-50px)' },
+]" fill="forwards">
             <div class="red-square"></div>
 
             <div class="buttons">
@@ -41,17 +35,12 @@
           <IonLabel color="primary">
             <strong>Keyframes animation</strong>
           </IonLabel>
-          <IonAnimation
-            v-slot="{ animation }"
-            :duration="3000"
-            :keyframes="[
-              { offset: 0, transform: 'scale(1) translate(0, 0)' },
-              { offset: 0.4, transform: 'scale(1.05) translate(15px, 15px)' },
-              { offset: 0.6, transform: 'scale(1.05) translate(-30px, 15px)' },
-              { offset: 1, transform: 'scale(1) translate(0, 0)' },
-            ]"
-            fill="none"
-          >
+          <IonAnimation id="animation2" v-slot="{ animation }" :duration="3000" :keyframes="[
+  { offset: 0, transform: 'scale(1) translate(0, 0)' },
+  { offset: 0.4, transform: 'scale(1.05) translate(15px, 15px)' },
+  { offset: 0.6, transform: 'scale(1.05) translate(-30px, 15px)' },
+  { offset: 1, transform: 'scale(1) translate(0, 0)' },
+]" fill="none">
             <div class="blue-square"></div>
 
             <div class="buttons">
@@ -66,16 +55,11 @@
           <IonLabel color="primary">
             <strong>Animation that repeats forever</strong>
           </IonLabel>
-          <IonAnimation
-            v-slot="{ animation }"
-            :duration="1000"
-            :keyframes="[
-              { offset: 0, transform: 'scale(1)' },
-              { offset: 0.75, transform: 'scale(1.05)' },
-              { offset: 1, transform: 'scale(1)' },
-            ]"
-            :iterations="Infinity"
-          >
+          <IonAnimation id="animation3" v-slot="{ animation }" :duration="1000" :keyframes="[
+  { offset: 0, transform: 'scale(1)' },
+  { offset: 0.75, transform: 'scale(1.05)' },
+  { offset: 1, transform: 'scale(1)' },
+]" :iterations="Infinity">
             <div class="green-square"></div>
 
             <div class="buttons">
@@ -90,24 +74,15 @@
           <IonLabel color="primary">
             <strong>Animation with style hooks</strong>
           </IonLabel>
-          <IonAnimation
-            v-slot="{ animation }"
-            :duration="2000"
-            :keyframes="[
-              { offset: 0, transform: 'scale(1)' },
-              { offset: 0.75, transform: 'scale(1.1)' },
-              { offset: 1, transform: 'scale(1)' },
-            ]"
-            :beforeStyles="{
-              opacity: 0.5,
-            }"
-            :afterClearStyles="['opacity']"
-            :afterStyles="{
-              transform: 'scale(0.9)',
-            }"
-            :beforeClearStyles="['transform']"
-            fill="none"
-          >
+          <IonAnimation id="animation4" v-slot="{ animation }" :duration="2000" :keyframes="[
+  { offset: 0, transform: 'scale(1)' },
+  { offset: 0.75, transform: 'scale(1.1)' },
+  { offset: 1, transform: 'scale(1)' },
+]" :beforeStyles="{
+  opacity: 0.5,
+}" :afterClearStyles="['opacity']" :afterStyles="{
+  transform: 'scale(0.9)',
+}" :beforeClearStyles="['transform']" fill="none">
             <div class="red-square"></div>
 
             <div class="buttons">
@@ -122,25 +97,20 @@
           <IonLabel color="primary">
             <strong>Animation with specific easing</strong>
           </IonLabel>
-          <IonAnimation
-            v-slot="{ animation }"
-            :duration="2000"
-            :keyframes="[
-              {
-                offset: 0,
-                transform: 'rotate(0)',
-              },
-              {
-                offset: 0.5,
-                transform: 'rotate(60deg)',
-              },
-              {
-                offset: 1,
-                transform: 'rotate(0)',
-              },
-            ]"
-            easing="cubic-bezier(.7,.55,0,1.15)"
-          >
+          <IonAnimation id="animation5" v-slot="{ animation }" :duration="2000" :keyframes="[
+  {
+    offset: 0,
+    transform: 'rotate(0)',
+  },
+  {
+    offset: 0.5,
+    transform: 'rotate(60deg)',
+  },
+  {
+    offset: 1,
+    transform: 'rotate(0)',
+  },
+]" easing="cubic-bezier(.7,.55,0,1.15)">
             <div class="blue-square"></div>
 
             <div class="buttons">
@@ -155,19 +125,13 @@
           <IonLabel color="primary">
             <strong>Reversed animation direction</strong>
           </IonLabel>
-          <IonAnimation
-            v-slot="{ animation }"
-            :duration="3000"
-            :keyframes="[
-              { offset: 0, transform: 'scale(1)' },
-              { offset: 0.3, transform: 'scale(1.2)' },
-              { offset: 0.6, transform: 'scale(1.05)' },
-              { offset: 0.9, transform: 'scale(0.8)' },
-              { offset: 1, transform: 'scale(1)' },
-            ]"
-            direction="reverse"
-            easing="ease-in"
-          >
+          <IonAnimation id="animation6" v-slot="{ animation }" :duration="3000" :keyframes="[
+  { offset: 0, transform: 'scale(1)' },
+  { offset: 0.3, transform: 'scale(1.2)' },
+  { offset: 0.6, transform: 'scale(1.05)' },
+  { offset: 0.9, transform: 'scale(0.8)' },
+  { offset: 1, transform: 'scale(1)' },
+]" direction="reverse" easing="ease-in">
             <div class="green-square"></div>
 
             <div class="buttons">
@@ -194,7 +158,7 @@
   text-align: center;
 }
 
-.animations-grid > *:nth-child(2) {
+.animations-grid>*:nth-child(2) {
   margin-left: auto;
   margin-right: auto;
 }

--- a/playground/pages/tabs/tab4.vue
+++ b/playground/pages/tabs/tab4.vue
@@ -17,10 +17,16 @@
           <IonLabel color="primary">
             <strong>Basic animation</strong>
           </IonLabel>
-          <IonAnimation id="animation1" v-slot="{ animation }" :duration="2000" :fromTo="[
-  { property: 'opacity', fromValue: '1', toValue: '0.2' },
-  { property: 'transform', fromValue: 'translateX(0px)', toValue: 'translateX(-50px)' },
-]" fill="forwards">
+          <IonAnimation
+            id="animation1"
+            v-slot="{ animation }"
+            :duration="2000"
+            :fromTo="[
+              { property: 'opacity', fromValue: '1', toValue: '0.2' },
+              { property: 'transform', fromValue: 'translateX(0px)', toValue: 'translateX(-50px)' },
+            ]"
+            fill="forwards"
+          >
             <div class="red-square"></div>
 
             <div class="buttons">
@@ -35,12 +41,18 @@
           <IonLabel color="primary">
             <strong>Keyframes animation</strong>
           </IonLabel>
-          <IonAnimation id="animation2" v-slot="{ animation }" :duration="3000" :keyframes="[
-  { offset: 0, transform: 'scale(1) translate(0, 0)' },
-  { offset: 0.4, transform: 'scale(1.05) translate(15px, 15px)' },
-  { offset: 0.6, transform: 'scale(1.05) translate(-30px, 15px)' },
-  { offset: 1, transform: 'scale(1) translate(0, 0)' },
-]" fill="none">
+          <IonAnimation
+            id="animation2"
+            v-slot="{ animation }"
+            :duration="3000"
+            :keyframes="[
+              { offset: 0, transform: 'scale(1) translate(0, 0)' },
+              { offset: 0.4, transform: 'scale(1.05) translate(15px, 15px)' },
+              { offset: 0.6, transform: 'scale(1.05) translate(-30px, 15px)' },
+              { offset: 1, transform: 'scale(1) translate(0, 0)' },
+            ]"
+            fill="none"
+          >
             <div class="blue-square"></div>
 
             <div class="buttons">
@@ -55,11 +67,17 @@
           <IonLabel color="primary">
             <strong>Animation that repeats forever</strong>
           </IonLabel>
-          <IonAnimation id="animation3" v-slot="{ animation }" :duration="1000" :keyframes="[
-  { offset: 0, transform: 'scale(1)' },
-  { offset: 0.75, transform: 'scale(1.05)' },
-  { offset: 1, transform: 'scale(1)' },
-]" :iterations="Infinity">
+          <IonAnimation
+            id="animation3"
+            v-slot="{ animation }"
+            :duration="1000"
+            :keyframes="[
+              { offset: 0, transform: 'scale(1)' },
+              { offset: 0.75, transform: 'scale(1.05)' },
+              { offset: 1, transform: 'scale(1)' },
+            ]"
+            :iterations="Infinity"
+          >
             <div class="green-square"></div>
 
             <div class="buttons">
@@ -74,15 +92,25 @@
           <IonLabel color="primary">
             <strong>Animation with style hooks</strong>
           </IonLabel>
-          <IonAnimation id="animation4" v-slot="{ animation }" :duration="2000" :keyframes="[
-  { offset: 0, transform: 'scale(1)' },
-  { offset: 0.75, transform: 'scale(1.1)' },
-  { offset: 1, transform: 'scale(1)' },
-]" :beforeStyles="{
-  opacity: 0.5,
-}" :afterClearStyles="['opacity']" :afterStyles="{
-  transform: 'scale(0.9)',
-}" :beforeClearStyles="['transform']" fill="none">
+          <IonAnimation
+            id="animation4"
+            v-slot="{ animation }"
+            :duration="2000"
+            :keyframes="[
+              { offset: 0, transform: 'scale(1)' },
+              { offset: 0.75, transform: 'scale(1.1)' },
+              { offset: 1, transform: 'scale(1)' },
+            ]"
+            :beforeStyles="{
+              opacity: 0.5,
+            }"
+            :afterClearStyles="['opacity']"
+            :afterStyles="{
+              transform: 'scale(0.9)',
+            }"
+            :beforeClearStyles="['transform']"
+            fill="none"
+          >
             <div class="red-square"></div>
 
             <div class="buttons">
@@ -97,20 +125,26 @@
           <IonLabel color="primary">
             <strong>Animation with specific easing</strong>
           </IonLabel>
-          <IonAnimation id="animation5" v-slot="{ animation }" :duration="2000" :keyframes="[
-  {
-    offset: 0,
-    transform: 'rotate(0)',
-  },
-  {
-    offset: 0.5,
-    transform: 'rotate(60deg)',
-  },
-  {
-    offset: 1,
-    transform: 'rotate(0)',
-  },
-]" easing="cubic-bezier(.7,.55,0,1.15)">
+          <IonAnimation
+            id="animation5"
+            v-slot="{ animation }"
+            :duration="2000"
+            :keyframes="[
+              {
+                offset: 0,
+                transform: 'rotate(0)',
+              },
+              {
+                offset: 0.5,
+                transform: 'rotate(60deg)',
+              },
+              {
+                offset: 1,
+                transform: 'rotate(0)',
+              },
+            ]"
+            easing="cubic-bezier(.7,.55,0,1.15)"
+          >
             <div class="blue-square"></div>
 
             <div class="buttons">
@@ -125,13 +159,20 @@
           <IonLabel color="primary">
             <strong>Reversed animation direction</strong>
           </IonLabel>
-          <IonAnimation id="animation6" v-slot="{ animation }" :duration="3000" :keyframes="[
-  { offset: 0, transform: 'scale(1)' },
-  { offset: 0.3, transform: 'scale(1.2)' },
-  { offset: 0.6, transform: 'scale(1.05)' },
-  { offset: 0.9, transform: 'scale(0.8)' },
-  { offset: 1, transform: 'scale(1)' },
-]" direction="reverse" easing="ease-in">
+          <IonAnimation
+            id="animation6"
+            v-slot="{ animation }"
+            :duration="3000"
+            :keyframes="[
+              { offset: 0, transform: 'scale(1)' },
+              { offset: 0.3, transform: 'scale(1.2)' },
+              { offset: 0.6, transform: 'scale(1.05)' },
+              { offset: 0.9, transform: 'scale(0.8)' },
+              { offset: 1, transform: 'scale(1)' },
+            ]"
+            direction="reverse"
+            easing="ease-in"
+          >
             <div class="green-square"></div>
 
             <div class="buttons">
@@ -158,7 +199,7 @@
   text-align: center;
 }
 
-.animations-grid>*:nth-child(2) {
+.animations-grid > *:nth-child(2) {
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/runtime/components/IonAnimation.vue
+++ b/src/runtime/components/IonAnimation.vue
@@ -63,7 +63,7 @@ const props = withDefaults(defineProps<AnimationOptions>(), {
   afterClearStyles: null,
 })
 
-const element = ref<HTMLDivElement>(null as any)
+const element = ref<HTMLDivElement | null>(null)
 
 const animation = ref<Animation>(createAnimation(props.id))
 
@@ -84,8 +84,6 @@ onMounted(() => {
     .afterStyles(props.afterStyles ?? {})
     .afterAddClass(props.afterAddClass ?? [])
     .afterClearStyles(props.afterClearStyles ?? [])
-
-  console.log(animation.value)
 
   let hasKeyframes = Array.isArray(props.keyframes) && props.keyframes.length > 0
 

--- a/src/runtime/components/IonAnimation.vue
+++ b/src/runtime/components/IonAnimation.vue
@@ -65,7 +65,7 @@ const props = withDefaults(defineProps<AnimationOptions>(), {
 
 const element = ref<HTMLDivElement | null>(null)
 
-const animation = ref<Animation>(createAnimation(props.id))
+const animation = ref<Animation | null>(null)
 
 let observer: IntersectionObserver
 
@@ -95,7 +95,7 @@ onMounted(() => {
   if (props.from !== null && !hasKeyframes) {
     if (Array.isArray(props.from)) {
       props.from.forEach(({ property, fromValue }) => {
-        animation.value.from(property, fromValue)
+        animation.value!.from(property, fromValue)
       })
     } else {
       animation.value.from(props.from.property, props.from.fromValue)
@@ -106,7 +106,7 @@ onMounted(() => {
   if (props.fromTo !== null && !hasKeyframes) {
     if (Array.isArray(props.fromTo)) {
       props.fromTo.forEach(({ property, fromValue, toValue }) => {
-        animation.value.fromTo(property, fromValue, toValue)
+        animation.value!.fromTo(property, fromValue, toValue)
       })
     } else {
       animation.value.fromTo(props.fromTo.property, props.fromTo.fromValue, props.fromTo.toValue)
@@ -117,7 +117,7 @@ onMounted(() => {
     observer = new IntersectionObserver(
       () => {
         // Play animation
-        animation.value.play()
+        animation.value!.play()
         // Disconnect observer - making animation always trigger ONLY ONCE
         observer.disconnect()
       },
@@ -134,7 +134,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   //Destroy animation and disconnect observer when component is about to be unmounted if it is defined
-  animation.value.destroy()
+  animation.value?.destroy()
   if (observer) observer.disconnect()
 })
 </script>


### PR DESCRIPTION
Fixes #270 

After playing around, it seems that for some reason slots can't be detected as reference elements anymore, so I had to add div wrapper for it. Not sure if this has some implications that I'm unaware of, but now it works like it used to :)