### PR TITLE
docs: steps to enable different package managers for capacitor

### DIFF
--- a/docs/content/2.getting-started.md
+++ b/docs/content/2.getting-started.md
@@ -45,13 +45,41 @@ The first time you start a Nuxt project with `@nuxtjs/ionic` enabled, a `ionic.c
 
 The good news is that it's installed by default with `@nuxtjs/ionic`, but you will need to enable it and choose what platforms you want to support.
 
-> The Ionic CLI is available via `npx` or can be installed globally with `npm install -g @ionic/cli` or `yarn global add @ionic/cli`.
+> The Ionic CLI is available via `npx` or can be installed globally with `npm install -g @ionic/cli` or `yarn global add @ionic/cli` or `pnpm add -g @ionic/cli`.
 
-```bash
-npx @ionic/cli integrations enable capacitor # or ionic integrations enable capacitor
-npx @ionic/cli capacitor add ios # or ionic capacitor add ios
-npx @ionic/cli capacitor add android # or ionic capacitor add android
+::code-group
+
+```bash [npx]
+npx @ionic/cli integrations enable capacitor
+npx @ionic/cli capacitor add ios
+npx @ionic/cli capacitor add android
 ```
+
+```bash [npm]
+# ionic config set -g npmClient npm
+
+ionic integrations enable capacitor
+ionic capacitor add ios
+ionic capacitor add android
+```
+
+```bash [yarn]
+ionic config set -g npmClient yarn
+
+ionic integrations enable capacitor
+ionic capacitor add ios
+ionic capacitor add android
+```
+
+```bash [pnpm]
+ionic config set -g npmClient pnpm
+
+ionic integrations enable capacitor
+ionic capacitor add ios
+ionic capacitor add android
+```
+
+::
 
 ### Run on iOS or Android
 


### PR DESCRIPTION

When using npx or a globally installed Ionic CLI, it doesn't automatically recognize if the project uses pnpm for example, because the npmClient config is set to 'npm' by default, so naturally it uses npm during the enabling process. This behavior may not be desirable.

Using `ionic config set -g npmClient pnpm` fixes the problem.