### PR TITLE
fix(router): sync current route for the same component

### DIFF
--- a/src/runtime/router.ts
+++ b/src/runtime/router.ts
@@ -69,9 +69,7 @@ export default defineNuxtPlugin(async nuxtApp => {
   router.afterEach((to, from) => {
     // We won't trigger suspense if the component is reused between routes
     // so we need to update the route manually
-    if (to.matched[0]?.components?.default === from.matched[0]?.components?.default) {
-      syncCurrentRoute()
-    }
+    syncCurrentRoute()
   })
 
   // https://github.com/vuejs/router/blob/main/packages/router/src/router.ts#L1225-L1233


### PR DESCRIPTION
Hi there!

I finally migrated my Vue Ionic app to Nuxt. Most of the Vite configuration like setting up auto-imports etc. can be thrown away. Nuxt does so much out of the box, even in non-SSR mode. Thanks a lot for Nuxt as well as this plugin! Finally, I can use suspense routes in the Ionic setup. A dream come true.

But I ran into a problem: Navigating between routes using different page components doesn't update the `route` state. I investigate the issue and found:
```ts
if (to.matched[0]?.components?.default === from.matched[0]?.components?.default) {}
```

Why do you guard the route sync to the same component? Can't we just sync the current route no matter what? It fixed my stale route state issue.

No minimal reproducible example provided. If you need one, please drop me a line.