### PR TITLE
feat: load app name from `capacitor.config.{json,js,ts}`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,7 @@ import {
   addImportsSources,
 } from '@nuxt/kit'
 import { join, resolve } from 'pathe'
-import { readPackageJSON } from 'pkg-types'
+import { loadConfig } from 'c12'
 import { defineUnimportPreset } from 'unimport'
 
 import { runtimeDir } from './utils'
@@ -21,6 +21,7 @@ import { setupMeta } from './parts/meta'
 import { setupPWA } from './parts/pwa'
 import { setupRouter } from './parts/router'
 
+import type { CapacitorConfig } from '@capacitor/cli'
 import type { AnimationBuilder, SpinnerTypes, PlatformConfig } from '@ionic/vue'
 
 export interface ModuleOptions {
@@ -114,17 +115,29 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Create an Ionic config file if it doesn't exist yet
+    // Create an Ionic config file if it doesn't exist yet
     const ionicConfigPath = join(nuxt.options.rootDir, 'ionic.config.json')
     if (!existsSync(ionicConfigPath)) {
+      // Look for any `capacitor.config.{json,js,ts}` and load it
+      const { config } = await loadConfig<CapacitorConfig>({
+        cwd: nuxt.options.rootDir,
+        name: 'capacitor',
+        rcFile: false,
+        jitiOptions: {
+          interopDefault: true,
+          esmResolve: true,
+        },
+      })
+
       await fsp.writeFile(
         ionicConfigPath,
         JSON.stringify(
           {
-            name: await readPackageJSON(nuxt.options.rootDir).then(
-              ({ name }) => name || 'nuxt-ionic-project'
-            ),
-            integrations: {},
-            type: 'vue',
+            name: config?.appName || 'nuxt-ionic-project',
+            integrations: {
+              capacitor: {},
+            },
+            type: 'vue-vite',
           },
           null,
           2


### PR DESCRIPTION
As of right now, the app name for the to-be-generated `ionic.config.json` is derived from the local `package.json`. This results in the following `appName`:

```json5
// ionic.config.json
{
  "name": "my-app",
}
```

But the official [Ionic configuration recommends](https://ionicframework.com/docs/cli/configuration#project-configuration-file):
```json5
// ionic.config.json
{
  // The human-readable name of the app.
  "name": "My App"
}
```

I believe a better approach is to use any of the existing Capacitor configs, as it includes the to be published app name:
- `capacitor.config.json`
- `capacitor.config.ts`
- etc.

Since a valid `name` for a `package.json` isn't allowed to include uppercase letters, the Capacitor config holds the more appropriate app name.