### PR TITLE
fix: disable payload extraction (closes #460)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -107,6 +107,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.build.transpile.push(runtimeDir)
     nuxt.options.build.transpile.push(/@ionic/, /@stencil/)
 
+    // Disable payload extraction, otherwise it will break the non-SSR build
+    nuxt.options.experimental.payloadExtraction = false
+
     // Inject options for the Ionic Vue plugin as a virtual module
     addTemplate({
       filename: 'ionic/vue-config.mjs',


### PR DESCRIPTION
I'm not sure what causes the issue, but disabling payload extraction is required for the generated SSG build to work properly.

With the payload extraction enabled by default, the error described in #460 will occur.

This feels like a workaround and I'm sure there's a better solution out there. I just don't know what to look for. Any help would be appreciated.