### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/nuxt-modules/ionic
-snippet: yarn add --dev @nuxtjs/ionic
+snippet: npx nuxi@latest module add ionic
 ---
 
 #title

--- a/docs/content/1.get-started/2.installation.md
+++ b/docs/content/1.get-started/2.installation.md
@@ -17,22 +17,9 @@ Get started quickly by installing and setting up this module with the following 
 ## Installation
 
 Add `@nuxtjs/ionic` to your project's dev dependencies:
-
-::code-group
-
-```bash [yarn]
-yarn add --dev @nuxtjs/ionic
+```bash
+npx nuxi@latest module add ionic
 ```
-
-```bash [npm]
-npm install @nuxtjs/ionic -D
-```
-
-```bash [pnpm]
-pnpm install @nuxtjs/ionic -D
-```
-
-::
 
 ### Nuxt Module
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
