### PR TITLE
Typo in head.ts

### DIFF
--- a/src/runtime/composables/head.ts
+++ b/src/runtime/composables/head.ts
@@ -3,7 +3,7 @@ import { getActiveHead } from 'unhead'
 import type { useHead as useHead$1 } from '@unhead/vue'
 import { onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
-import { useRouter } from '#vue-router'
+import { useRouter } from 'vue-router'
 
 // This is used to store the active head for each path as long as the path's page is still in the DOM
 const headMap = new Map<


### PR DESCRIPTION
Hi,

found a typo in head.ts composable which causes:

Pre-transform error: Failed to resolve import "#vue-router" from "node_modules/@nuxtjs/ionic/dist/runtime/composables/head.mjs?v=ccfb2c39".