### PR TITLE
chore(playground): update type in ionic.config.json

### DIFF
--- a/playground/ionic.config.json
+++ b/playground/ionic.config.json
@@ -3,5 +3,5 @@
   "integrations": {
     "capacitor": {}
   },
-  "type": "vue-vite"
+  "type": "custom"
 }


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Update the `ionic.config.json` of the playground, by changing the `type` to `custom`:

```json
{
  "type": "custom"
}
```

This ensures Ionic uses the correct CLI, Nuxi, instead of expecting the Vite CLI when the type is set to `vue-vite` as in the reference [here](https://github.com/ionic-team/vscode-ionic/blob/main/src/ionic-serve.ts#L89).


