### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -160,7 +160,7 @@ export default defineNuxtModule<ModuleOptions>({
       }),
     ])
 
-    if (nuxt.options._generate) {
+    if (nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
       nuxt.hook('nitro:config', async (config) => {
         config.prerender ||= {}
         config.prerender.routes ||= []

--- a/src/module.ts
+++ b/src/module.ts
@@ -160,6 +160,7 @@ export default defineNuxtModule<ModuleOptions>({
       }),
     ])
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
       nuxt.hook('nitro:config', async (config) => {
         config.prerender ||= {}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.