### PR TITLE
fix(head): resolve reactive input before pushing to unhead

### DIFF
--- a/playground/pages/reactive-head.vue
+++ b/playground/pages/reactive-head.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const count = ref(0)
+
+const title = computed(() => `Reactive Head - ${count.value}`)
+const styleContent = computed(() => `.reactive-head-probe { --count: ${count.value} }`)
+
+useHead({
+  title,
+  style: [{ innerHTML: styleContent, id: 'reactive-head-style' }],
+})
+</script>
+
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Reactive head</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content :fullscreen="true">
+      <ion-button
+        class="reactive-head-increment"
+        @click="count++"
+      >
+        Increment
+      </ion-button>
+      <ion-label class="reactive-head-count">
+        {{ count }}
+      </ion-label>
+    </ion-content>
+  </ion-page>
+</template>

--- a/src/runtime/composables/head.ts
+++ b/src/runtime/composables/head.ts
@@ -25,15 +25,10 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
 
   let innerObj = obj
 
-  /* `@unhead/vue` resolves reactive input before pushing it (see `clientUseHead`), but only in the
-     composable we are replacing here — the client head has no prop resolver of its own. Refs would
-     otherwise reach the DOM renderer unresolved, where `JSON.stringify` on a `style`/`script`
-     innerHTML throws `Converting circular structure to JSON` and every other prop renders the ref
-     instead of its value. */
+  // Reactive input has to be resolved before it reaches unhead, as `clientUseHead` does
   const resolveInput = (input: UseHeadInput<T>) => walkResolver(input, VueResolver) as UseHeadInput<T>
 
-  /* The map is keyed by the input object identity, so it always holds the raw input — only the
-     value handed to unhead is resolved */
+  // The map keeps the raw input as its key, only what we hand to unhead is resolved
   const findActiveEntry = () => headMap.get(currentPath)?.find(headVal => headVal[0] === innerObj)?.[1]
 
   const __returned: Omit<ActiveHeadEntry<UseHeadInput<T>>, '_poll'> = {
@@ -72,8 +67,8 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
     headMap.set(currentPath, [...metaArr, [obj, headObj]])
   }
 
-  /* Keep reactive input in sync, the same way `clientUseHead` does. The entry is looked up on each
-     run because `onIonViewDidEnter` disposes and re-pushes it */
+  /* Keep the entry in sync with the input, looking it up on each run
+     because `onIonViewDidEnter` disposes and re-pushes it */
   if (getCurrentScope()) {
     let isInitialRun = true
     watchEffect(() => {

--- a/src/runtime/composables/head.ts
+++ b/src/runtime/composables/head.ts
@@ -1,7 +1,8 @@
 import { onIonViewDidEnter, onIonViewDidLeave } from '@ionic/vue'
 import type { ActiveHeadEntry, UseHeadInput, UseHeadOptions } from '@unhead/vue/types'
 import type { useHead as _useHead } from '@unhead/vue'
-import { getCurrentInstance, onBeforeUnmount } from 'vue'
+import { VueResolver, walkResolver } from '@unhead/vue/utils'
+import { getCurrentInstance, getCurrentScope, onBeforeUnmount, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { injectHead } from '#imports'
 
@@ -23,6 +24,18 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
   const currentPath = (instance && useRoute().path) || ''
 
   let innerObj = obj
+
+  /* `@unhead/vue` resolves reactive input before pushing it (see `clientUseHead`), but only in the
+     composable we are replacing here — the client head has no prop resolver of its own. Refs would
+     otherwise reach the DOM renderer unresolved, where `JSON.stringify` on a `style`/`script`
+     innerHTML throws `Converting circular structure to JSON` and every other prop renders the ref
+     instead of its value. */
+  const resolveInput = (input: UseHeadInput<T>) => walkResolver(input, VueResolver) as UseHeadInput<T>
+
+  /* The map is keyed by the input object identity, so it always holds the raw input — only the
+     value handed to unhead is resolved */
+  const findActiveEntry = () => headMap.get(currentPath)?.find(headVal => headVal[0] === innerObj)?.[1]
+
   const __returned: Omit<ActiveHeadEntry<UseHeadInput<T>>, '_poll'> = {
     dispose() {
       // Can just easily mutate the array instead of wasting little CPU to slice/spread it :P
@@ -41,7 +54,7 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
       if (headArrIndex === -1) return
       const [, headToPatch] = headArr[headArrIndex]!
       innerObj = newObj
-      headToPatch?.patch(innerObj)
+      headToPatch?.patch(resolveInput(innerObj))
       headArr.splice(headArrIndex, 1, [innerObj, headToPatch])
       headMap.set(currentPath, headArr)
     },
@@ -50,13 +63,27 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
   /* Initially assign the head to the respected slots in the map
      because Ionic components don't unmount the way we expect them to */
   if (!headMap.has(currentPath)) {
-    const headObj = activeHead?.push(obj)
+    const headObj = activeHead?.push(resolveInput(obj))
     headMap.set(currentPath, [[obj, headObj]])
   }
   else {
-    const headObj = activeHead?.push(obj)
+    const headObj = activeHead?.push(resolveInput(obj))
     const metaArr = headMap.get(currentPath) || []
     headMap.set(currentPath, [...metaArr, [obj, headObj]])
+  }
+
+  /* Keep reactive input in sync, the same way `clientUseHead` does. The entry is looked up on each
+     run because `onIonViewDidEnter` disposes and re-pushes it */
+  if (getCurrentScope()) {
+    let isInitialRun = true
+    watchEffect(() => {
+      const resolved = resolveInput(innerObj)
+      if (isInitialRun) {
+        isInitialRun = false
+        return
+      }
+      findActiveEntry()?.patch(resolved)
+    })
   }
 
   // Only use lifecycle hooks if called inside component setup
@@ -97,7 +124,7 @@ export function useHead<T extends Record<string, any>>(obj: UseHeadInput<T>, _?:
         if (headArr) {
           headArr = headArr.map(([obj, head]) => {
             head?.dispose()
-            const newHead = activeHead?.push(obj)
+            const newHead = activeHead?.push(resolveInput(obj))
             return [obj, newHead]
           })
           headMap.set(currPath, headArr)

--- a/test/e2e/ion-head.spec.ts
+++ b/test/e2e/ion-head.spec.ts
@@ -85,7 +85,6 @@ describe('Nuxt Ionic useHead', async () => {
     await page.goto(url('/reactive-head'), { waitUntil: 'hydration' })
     await expectTitleToBe(page, 'Reactive Head - 0')
 
-    // an unresolved ref reaches `JSON.stringify` as a `ComputedRefImpl`
     await page.waitForFunction(() => document.getElementById('reactive-head-style')?.textContent?.includes('--count: 0'))
 
     await page.click('.reactive-head-increment')

--- a/test/e2e/ion-head.spec.ts
+++ b/test/e2e/ion-head.spec.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { setup, createPage, url } from '@nuxt/test-utils/e2e'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { Page } from 'playwright-core'
 
 function expectTitleToBe(page: Page, title: string) {
@@ -73,6 +73,26 @@ describe('Nuxt Ionic useHead', async () => {
     // Navigate to tabs/tab1
     await page.click('#tab-button-tab1')
     await expectTitleToBe(page, 'Explore Container - Tab 1')
+
+    await page.close()
+  })
+
+  it('useHead should resolve reactive input on the client', { timeout: 120_000 }, async () => {
+    const page = await createPage()
+    const errors: string[] = []
+    page.on('pageerror', error => errors.push(error.message))
+
+    await page.goto(url('/reactive-head'), { waitUntil: 'hydration' })
+    await expectTitleToBe(page, 'Reactive Head - 0')
+
+    // an unresolved ref reaches `JSON.stringify` as a `ComputedRefImpl`
+    await page.waitForFunction(() => document.getElementById('reactive-head-style')?.textContent?.includes('--count: 0'))
+
+    await page.click('.reactive-head-increment')
+    await expectTitleToBe(page, 'Reactive Head - 1')
+    await page.waitForFunction(() => document.getElementById('reactive-head-style')?.textContent?.includes('--count: 1'))
+
+    expect(errors).toEqual([])
 
     await page.close()
   })


### PR DESCRIPTION
Fixes #1004

### 🔗 Linked issue

Issue #1004 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`@unhead/vue`'s `clientUseHead` resolves reactive input with `walkResolver(input, VueResolver)` inside a `watchEffect` before pushing an entry. The composable this module registers in its place pushed the raw input, and the client head has no prop resolver of its own — `@unhead/vue/server` is the only one created with `propResolvers: [VueResolver]`, which is why this never showed up during SSR.

I used Claude Opus 5 to analyze the problem and find a possible solution, before submit PR I review the code and make some changes on my own (I prefer to let "claude contribute" in the commit for transparency).
Currently I have already a workaround on my business projects to fix this error, so I decide to contribute to the repository.